### PR TITLE
Rewrite minifier to allow future extension

### DIFF
--- a/Kaskada.Minify.Tests/MinifierTests/MinifyFromTextTests.cs
+++ b/Kaskada.Minify.Tests/MinifierTests/MinifyFromTextTests.cs
@@ -86,8 +86,8 @@ namespace Kaskada.Minify.Tests.MinifierTests
         [Fact]
         public void Minify_ShouldNotRemoveWhitespaceInAtRules() =>
             AssertResultAsExpected(
-                "@media screen and ( min-width: 900px; ){ p { color: red; } } @import \"common.css\" screen;",
-                "@media screen and (min-width:900px;){p{color:red}}@import \"common.css\" screen;");
+                "@media screen and ( min-width: 900px ){ p { color: red; } } @import \"common.css\" screen;",
+                "@media screen and (min-width:900px){p{color:red}}@import \"common.css\" screen;");
 
         [Fact]
         public void Minify_ShouldRemoveLastSemicolonInBlock() =>
@@ -97,9 +97,21 @@ namespace Kaskada.Minify.Tests.MinifierTests
 
         [Fact]
         public void Minify_ShouldNotRemoveSemicolonInAtRule() =>
+        AssertResultAsExpected(
+            "@import url('file.css'); @import url('file.css') screen and (orientation: landscape);",
+            "@import url('file.css');@import url('file.css')screen and (orientation:landscape);");
+
+        [Fact]
+        public void Minify_ShouldNotRemoveWhitespaceBetweenParenthesisAndClassSelector() =>
             AssertResultAsExpected(
-                "@import url('file.css'); @import url('file.css') screen and (orientation: landscape);",
-                "@import url('file.css');@import url('file.css')screen and (orientation:landscape);");
+                ".foo:not(:hover) .bar {}",
+                ".foo:not(:hover) .bar{}");
+
+        [Fact]
+        public void Minify_ShouldRemoveWhitespaceBetweenSelectorAndDeclaration() =>
+            AssertResultAsExpected(
+                ".main .article { background: none repeat scroll 0 0 #c4c54a; }",
+                ".main .article{background:none repeat scroll 0 0 #c4c54a}");
 
         private void AssertResultAsExpected(
             string input,
@@ -111,7 +123,9 @@ namespace Kaskada.Minify.Tests.MinifierTests
             minifier.Minify(textOutput);
             string actual = textOutput.ToString();
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(
+                expected,
+                actual);
         }
     }
 }

--- a/Kaskada.Minify.Tests/MinifierTests/MinifyFromTextTests.cs
+++ b/Kaskada.Minify.Tests/MinifierTests/MinifyFromTextTests.cs
@@ -90,6 +90,12 @@ namespace Kaskada.Minify.Tests.MinifierTests
                 "@media screen and (min-width:900px){p{color:red}}@import \"common.css\" screen;");
 
         [Fact]
+        public void Minify_ShouldRemoveNewLinesInAtRulesSelectors() =>
+            AssertResultAsExpected(
+                "@media screen and ( min-width: 900px ){\n  p { color: red; } } @import \"common.css\" screen;",
+                "@media screen and (min-width:900px){p{color:red}}@import \"common.css\" screen;");
+
+        [Fact]
         public void Minify_ShouldRemoveLastSemicolonInBlock() =>
             AssertResultAsExpected(
                 "body { color: red; padding: 10px; }",

--- a/Kaskada.Minify/Cursors/TextCursor.cs
+++ b/Kaskada.Minify/Cursors/TextCursor.cs
@@ -15,7 +15,6 @@ internal sealed class TextCursor : ICursor
 
     public bool HasMoreInput { get; private set; } = true;
 
-
     public void Dispose() =>
         _text = string.Empty;
 

--- a/Kaskada.Minify/KaskadaException.cs
+++ b/Kaskada.Minify/KaskadaException.cs
@@ -1,0 +1,31 @@
+﻿namespace Kaskada.Minify;
+
+[Serializable]
+public class KaskadaException : Exception
+{
+    public KaskadaException()
+    {
+    }
+
+    public KaskadaException(string message)
+        : base(message)
+    {
+    }
+
+    public KaskadaException(string message,
+        Exception inner)
+        : base(
+            message,
+            inner)
+    {
+    }
+
+    protected KaskadaException(
+        System.Runtime.Serialization.SerializationInfo info,
+        System.Runtime.Serialization.StreamingContext context)
+        : base(
+            info,
+            context)
+    {
+    }
+}

--- a/Kaskada.Minify/Minifier.cs
+++ b/Kaskada.Minify/Minifier.cs
@@ -3,20 +3,68 @@ global using Kaskada.Minify.Outputs;
 
 namespace Kaskada.Minify;
 
+public enum State
+{
+    None,
+    Comment,
+    Selector,
+    Declaration,
+    AtRule
+}
+
 public sealed class Minifier : IDisposable
 {
     private readonly ICursor _cursor;
+
+    private readonly Stack<State> _states = new(new[] {State.None});
 
     private bool _hasSemicolonInBuffer;
 
     private static readonly HashSet<char> PreDelimiters = new()
     {
-        '[', '{', ':', ';', '=', '!', '&', '|', '?', '+', '-', '~', '*', '/', '\n', '>', ',', '@', ')'
+        '[',
+        '{',
+        ':',
+        ';',
+        '=',
+        '!',
+        '&',
+        '|',
+        '?',
+        '+',
+        '-',
+        '~',
+        '*',
+        '/',
+        '\n',
+        '>',
+        ',',
+        '@',
     };
 
     private static readonly HashSet<char> PostDelimiters = new()
     {
-        '(', '[', '{', ':', ';', '=', '!', '&', '|', '?', '+', '-', '~', '*', '/', '\n', '>', ',', '@', ')', '}'
+        '(',
+        '[',
+        '{',
+        ':',
+        ';',
+        '=',
+        '!',
+        '&',
+        '|',
+        '?',
+        '+',
+        '-',
+        '~',
+        '*',
+        '/',
+        '\n',
+        '>',
+        ',',
+        '@',
+        ')',
+        '}'
     };
 
     private Minifier(ICursor cursor) => _cursor = cursor;
@@ -27,82 +75,212 @@ public sealed class Minifier : IDisposable
 
     public void Dispose() => _cursor.Dispose();
 
-    public void Minify(IOutput output)
+    private void PushState(State state)
+    {
+        _states.Push(state);
+    }
+    
+    private void HandleComment()
     {
         while (_cursor.HasMoreInput)
         {
             _cursor.MoveNext();
 
-            if (_cursor.Current == '/' && _cursor.Peek() == '*')
+            if (_cursor.Current == '*' && _cursor.Peek() == '/')
             {
-                while (_cursor.HasMoreInput)
+                _cursor.MoveNext();
+                _cursor.MoveNext();
+                _states.Pop();
+
+                break;
+            }
+        }
+    }
+
+    private void HandleDeclaration(IOutput output)
+    {
+        if (char.IsWhiteSpace(_cursor.Current))
+        {
+            if (_cursor.Previous is '{' or ':' or ';' or '/')
+                return;
+
+            char? next = _cursor.Peek();
+            if (next is '}' or ':' or ')')
+                return;
+        }
+        
+        if (_cursor.Current == '/' && _cursor.Peek() == '*')
+        {
+            PushState(State.Comment);
+            return;
+        }
+
+        if (_cursor.Current is ';')
+        {
+            _hasSemicolonInBuffer = true;
+            return;
+        }
+        
+        if (_cursor.Current is '}')
+        {
+            _hasSemicolonInBuffer = false;
+            _states.Pop();
+        }
+        
+        if (_hasSemicolonInBuffer)
+        {
+            _hasSemicolonInBuffer = false;
+            output.Push(';');
+        }
+        
+        output.Push(_cursor.Current);
+    }
+
+    private void HandleSelector(IOutput output)
+    {
+        if (char.IsWhiteSpace(_cursor.Current))
+        {
+            if (IsPreDelimiter(_cursor.Previous))
+            {
+                return;
+            }
+
+            char? next = _cursor.Peek();
+            if (next is null)
+            {
+                return;
+            }
+
+            if (IsPostDelimiter(next.Value))
+            {
+                return;
+            }
+        }
+      
+        if (_cursor.Current is ';')
+        {
+            return;
+        }
+
+        if (_cursor.Current is '{')
+        {
+            _states.Pop();
+            PushState(State.Declaration);
+        }
+
+        output.Push(_cursor.Current);
+    }
+
+    private void HandleAtRule(IOutput output)
+    {
+        if (char.IsWhiteSpace(_cursor.Current))
+        {
+            if (_cursor.Previous == ' ')
+            {
+                return;
+            }
+
+            if (_cursor.Previous is ')' or '(')
+            {
+                return;
+            }
+
+            if (_cursor.Previous is ':')
+            {
+                return;
+            }
+
+            if (_cursor.Peek() is ')' or '}' or '@')
+            {
+                return;
+            }
+        }
+
+        if (_cursor.Current is '{')
+        {
+            PushState(State.Selector);
+        }
+        else if (_cursor.Current is ';' or '}')
+        {
+            _states.Pop();
+        }
+
+        output.Push(_cursor.Current);
+    }
+
+    public void Minify(IOutput output)
+    {
+        while (_cursor.HasMoreInput)
+        {
+            if (char.IsWhiteSpace(_cursor.Current))
+            {
+                char? next = _cursor.Peek();
+            
+                if (next is null)
                 {
                     _cursor.MoveNext();
-
-                    if (_cursor.Current == '*' && _cursor.Peek() == '/')
-                    {
-                        _cursor.MoveNext();
-                        _cursor.MoveNext();
-
-                        break;
-                    }
+                    continue;
+                }
+            
+                if (char.IsWhiteSpace(_cursor.Previous) || char.IsWhiteSpace(next.Value))
+                {
+                    _cursor.MoveNext();
+                    continue;
                 }
             }
 
-            if (!_cursor.HasMoreInput)
+            State currentState = _states.Peek();
+
+            if (currentState == State.None)
+            {
+                if (_cursor.Current is '.' or '#' || char.IsLetter(_cursor.Current))
+                {
+                    PushState(State.Selector);
+                    continue;
+                }
+                
+                if (_cursor.Current == '/' && _cursor.Peek() == '*')
+                {
+                    PushState(State.Comment);
+                    continue;
+                }
+
+                if (_cursor.Current == '@')
+                {
+                    PushState(State.AtRule);
+                    continue;
+                }
+
+                _cursor.MoveNext();
+
+                continue;
+            }
+
+            
+            if (currentState == State.Selector)
+            {
+                HandleSelector(output);
+            }
+            else if (currentState == State.Declaration)
+            {
+                HandleDeclaration(output);
+            }
+            else if (currentState == State.Comment)
+            {
+                HandleComment();
+            }
+            else if (currentState == State.AtRule)
+            {
+                HandleAtRule(output);
+            }
+
+            else if (!_cursor.HasMoreInput)
             {
                 break;
             }
 
-            if (_cursor.Current is '\n')
-            {
-                continue;
-            }
-
-            if (char.IsWhiteSpace(_cursor.Current))
-            {
-                char? next = _cursor.Peek();
-
-                if (next is null)
-                {
-                    continue;
-                }
-
-                if (char.IsWhiteSpace(_cursor.Previous) || char.IsWhiteSpace(next.Value))
-                {
-                    continue;
-                }
-
-                if (IsPostDelimiter(_cursor.Previous) || IsPreDelimiter(next.Value))
-                {
-                    continue;
-                }
-            }
-
-            if (_cursor.Current is ';')
-            {
-                _hasSemicolonInBuffer = true;
-                continue;
-            }
-
-            if (_hasSemicolonInBuffer)
-            {
-                if (_cursor.Current is not '}')
-                {
-                    output.Push(';');
-                }
-
-                _hasSemicolonInBuffer = false;
-            }
-
-            output.Push(_cursor.Current);
+            _cursor.MoveNext();
         }
-
-        if (_hasSemicolonInBuffer)
-        {
-            output.Push(';');
-        }
-
         output.Commit();
     }
 

--- a/Kaskada.Minify/Minifier.cs
+++ b/Kaskada.Minify/Minifier.cs
@@ -1,73 +1,19 @@
 ﻿global using Kaskada.Minify.Cursors;
 global using Kaskada.Minify.Outputs;
+using Kaskada.Minify.States;
 
 namespace Kaskada.Minify;
-
-public enum State
-{
-    None,
-    Comment,
-    Selector,
-    Declaration,
-    AtRule
-}
 
 public sealed class Minifier : IDisposable
 {
     private readonly ICursor _cursor;
+    private readonly StateMachine _stateMachine;
 
-    private readonly Stack<State> _states = new(new[] {State.None});
-
-    private bool _hasSemicolonInBuffer;
-
-    private static readonly HashSet<char> PreDelimiters = new()
+    private Minifier(ICursor cursor)
     {
-        '[',
-        '{',
-        ':',
-        ';',
-        '=',
-        '!',
-        '&',
-        '|',
-        '?',
-        '+',
-        '-',
-        '~',
-        '*',
-        '/',
-        '\n',
-        '>',
-        ',',
-        '@',
-    };
-
-    private static readonly HashSet<char> PostDelimiters = new()
-    {
-        '(',
-        '[',
-        '{',
-        ':',
-        ';',
-        '=',
-        '!',
-        '&',
-        '|',
-        '?',
-        '+',
-        '-',
-        '~',
-        '*',
-        '/',
-        '\n',
-        '>',
-        ',',
-        '@',
-        ')',
-        '}'
-    };
-
-    private Minifier(ICursor cursor) => _cursor = cursor;
+        _cursor = cursor;
+        _stateMachine = new StateMachine();
+    }
 
     public static Minifier FromFile(string filename) => new(new FileCursor(filename));
 
@@ -75,218 +21,14 @@ public sealed class Minifier : IDisposable
 
     public void Dispose() => _cursor.Dispose();
 
-    private void PushState(State state)
-    {
-        _states.Push(state);
-    }
-    
-    private void HandleComment()
-    {
-        while (_cursor.HasMoreInput)
-        {
-            _cursor.MoveNext();
-
-            if (_cursor.Current == '*' && _cursor.Peek() == '/')
-            {
-                _cursor.MoveNext();
-                _cursor.MoveNext();
-                _states.Pop();
-
-                break;
-            }
-        }
-    }
-
-    private void HandleDeclaration(IOutput output)
-    {
-        if (char.IsWhiteSpace(_cursor.Current))
-        {
-            if (_cursor.Previous is '{' or ':' or ';' or '/')
-                return;
-
-            char? next = _cursor.Peek();
-            if (next is '}' or ':' or ')')
-                return;
-        }
-        
-        if (_cursor.Current == '/' && _cursor.Peek() == '*')
-        {
-            PushState(State.Comment);
-            return;
-        }
-
-        if (_cursor.Current is ';')
-        {
-            _hasSemicolonInBuffer = true;
-            return;
-        }
-        
-        if (_cursor.Current is '}')
-        {
-            _hasSemicolonInBuffer = false;
-            _states.Pop();
-        }
-        
-        if (_hasSemicolonInBuffer)
-        {
-            _hasSemicolonInBuffer = false;
-            output.Push(';');
-        }
-        
-        output.Push(_cursor.Current);
-    }
-
-    private void HandleSelector(IOutput output)
-    {
-        if (char.IsWhiteSpace(_cursor.Current))
-        {
-            if (IsPreDelimiter(_cursor.Previous))
-            {
-                return;
-            }
-
-            char? next = _cursor.Peek();
-            if (next is null)
-            {
-                return;
-            }
-
-            if (IsPostDelimiter(next.Value))
-            {
-                return;
-            }
-        }
-      
-        if (_cursor.Current is ';')
-        {
-            return;
-        }
-
-        if (_cursor.Current is '{')
-        {
-            _states.Pop();
-            PushState(State.Declaration);
-        }
-
-        output.Push(_cursor.Current);
-    }
-
-    private void HandleAtRule(IOutput output)
-    {
-        if (char.IsWhiteSpace(_cursor.Current))
-        {
-            if (_cursor.Previous == ' ')
-            {
-                return;
-            }
-
-            if (_cursor.Previous is ')' or '(')
-            {
-                return;
-            }
-
-            if (_cursor.Previous is ':')
-            {
-                return;
-            }
-
-            if (_cursor.Peek() is ')' or '}' or '@')
-            {
-                return;
-            }
-        }
-
-        if (_cursor.Current is '{')
-        {
-            PushState(State.Selector);
-        }
-        else if (_cursor.Current is ';' or '}')
-        {
-            _states.Pop();
-        }
-
-        output.Push(_cursor.Current);
-    }
-
     public void Minify(IOutput output)
     {
+        _stateMachine.PushState<WhitespaceState>();
         while (_cursor.HasMoreInput)
         {
-            if (char.IsWhiteSpace(_cursor.Current))
-            {
-                char? next = _cursor.Peek();
-            
-                if (next is null)
-                {
-                    _cursor.MoveNext();
-                    continue;
-                }
-            
-                if (char.IsWhiteSpace(_cursor.Previous) || char.IsWhiteSpace(next.Value))
-                {
-                    _cursor.MoveNext();
-                    continue;
-                }
-            }
-
-            State currentState = _states.Peek();
-
-            if (currentState == State.None)
-            {
-                if (_cursor.Current is '.' or '#' || char.IsLetter(_cursor.Current))
-                {
-                    PushState(State.Selector);
-                    continue;
-                }
-                
-                if (_cursor.Current == '/' && _cursor.Peek() == '*')
-                {
-                    PushState(State.Comment);
-                    continue;
-                }
-
-                if (_cursor.Current == '@')
-                {
-                    PushState(State.AtRule);
-                    continue;
-                }
-
-                _cursor.MoveNext();
-
-                continue;
-            }
-
-            
-            if (currentState == State.Selector)
-            {
-                HandleSelector(output);
-            }
-            else if (currentState == State.Declaration)
-            {
-                HandleDeclaration(output);
-            }
-            else if (currentState == State.Comment)
-            {
-                HandleComment();
-            }
-            else if (currentState == State.AtRule)
-            {
-                HandleAtRule(output);
-            }
-
-            else if (!_cursor.HasMoreInput)
-            {
-                break;
-            }
-
+            _stateMachine.Process(_cursor, output);
             _cursor.MoveNext();
         }
         output.Commit();
     }
-
-    private static bool IsPreDelimiter(char value) =>
-        PreDelimiters.Contains(value);
-
-    private static bool IsPostDelimiter(char value) =>
-        PostDelimiters.Contains(value);
 }

--- a/Kaskada.Minify/Outputs/IOutput.cs
+++ b/Kaskada.Minify/Outputs/IOutput.cs
@@ -2,7 +2,7 @@
 
 public interface IOutput
 {
-    void Push(
+    void Append(
         char value);
 
     void Commit();

--- a/Kaskada.Minify/Outputs/IOutput.cs
+++ b/Kaskada.Minify/Outputs/IOutput.cs
@@ -6,4 +6,6 @@ public interface IOutput
         char value);
 
     void Commit();
+
+    char? Peek();
 }

--- a/Kaskada.Minify/Outputs/StreamOutput.cs
+++ b/Kaskada.Minify/Outputs/StreamOutput.cs
@@ -9,7 +9,7 @@ public sealed class StreamOutput : IOutput, IDisposable
         Stream stream) =>
         _streamWriter = new StreamWriter(stream);
 
-    public void Push(
+    public void Append(
         char value)
     {
         _streamWriter.Write(value);

--- a/Kaskada.Minify/Outputs/StreamOutput.cs
+++ b/Kaskada.Minify/Outputs/StreamOutput.cs
@@ -3,17 +3,23 @@
 public sealed class StreamOutput : IOutput, IDisposable
 {
     private readonly StreamWriter _streamWriter;
+    private char? _lastValue;
 
     public StreamOutput(
         Stream stream) =>
         _streamWriter = new StreamWriter(stream);
 
     public void Push(
-        char value) =>
+        char value)
+    {
         _streamWriter.Write(value);
+        _lastValue = value;
+    }
 
     public void Commit() =>
         _streamWriter.Flush();
+
+    public char? Peek() => _lastValue;
 
     public void Dispose() =>
         _streamWriter.Dispose();

--- a/Kaskada.Minify/Outputs/TextOutput.cs
+++ b/Kaskada.Minify/Outputs/TextOutput.cs
@@ -13,6 +13,8 @@ public sealed class TextOutput : IOutput
     public void Commit() =>
         _text = string.Join("", _output);
 
+    public char? Peek() => _output.Last();
+
     public override string ToString() =>
         _text;
 }

--- a/Kaskada.Minify/Outputs/TextOutput.cs
+++ b/Kaskada.Minify/Outputs/TextOutput.cs
@@ -6,7 +6,7 @@ public sealed class TextOutput : IOutput
 
     private string _text = string.Empty;
 
-    public void Push(
+    public void Append(
         char value) =>
         _output.Add(value);
 

--- a/Kaskada.Minify/States/AtRuleState.cs
+++ b/Kaskada.Minify/States/AtRuleState.cs
@@ -1,0 +1,48 @@
+﻿namespace Kaskada.Minify.States;
+
+internal class AtRuleState : State
+{
+    private static readonly HashSet<char> PostDelimiters = new()
+    {
+        ')', '(', ':', '}'
+    };
+
+    private static readonly HashSet<char> PreDelimiters = new()
+    {
+        ')', '}', '@'
+    };
+
+    public AtRuleState(StateMachine stateMachine)
+        : base(stateMachine)
+    {
+    }
+
+    public override void Process(ICursor cursor, IOutput output)
+    {
+        if (char.IsWhiteSpace(cursor.Current))
+        {
+            if (char.IsWhiteSpace(cursor.Previous) || PostDelimiters.Contains(cursor.Previous))
+            {
+                return;
+            }
+
+            char? next = cursor.Peek();
+
+            if (next is null || PreDelimiters.Contains(next.Value))
+            {
+                return;
+            }
+        }
+
+        if (cursor.Current is '{')
+        {
+            StateMachine.PushState<SelectorState>();
+        }
+        else if (cursor.Current is ';' or '}')
+        {
+            StateMachine.PopState();
+        }
+
+        output.Append(cursor.Current);
+    }
+}

--- a/Kaskada.Minify/States/CommentState.cs
+++ b/Kaskada.Minify/States/CommentState.cs
@@ -1,0 +1,17 @@
+﻿namespace Kaskada.Minify.States;
+
+internal class CommentState : State
+{
+    public CommentState(StateMachine stateMachine)
+        : base(stateMachine)
+    {
+    }
+
+    public override void Process(ICursor cursor, IOutput output)
+    {
+        if (cursor.Current == '/' && cursor.Previous == '*')
+        {
+            StateMachine.PopState();
+        }
+    }
+}

--- a/Kaskada.Minify/States/DeclarationState.cs
+++ b/Kaskada.Minify/States/DeclarationState.cs
@@ -1,0 +1,69 @@
+﻿namespace Kaskada.Minify.States;
+
+internal class DeclarationState : State
+{
+    private bool _hasSemicolonInBuffer;
+
+    private static readonly HashSet<char> PreDelimiters = new()
+    {
+        '{', ':', ';', '/'
+    };
+
+    private static readonly HashSet<char> PostDelimiters = new()
+    {
+        '}', ':', ')'
+    };
+
+    public DeclarationState(StateMachine stateMachine)
+        : base(stateMachine)
+    {
+    }
+
+    public override void Process(ICursor cursor, IOutput output)
+    {
+        if (char.IsWhiteSpace(cursor.Current))
+        {
+            if (char.IsWhiteSpace(cursor.Previous) || PreDelimiters.Contains(cursor.Previous))
+            {
+                return;
+            }
+
+            char? next = cursor.Peek();
+            if (next is null)
+            {
+                return;
+            }
+
+            if (char.IsWhiteSpace(next.Value) || PostDelimiters.Contains(next.Value))
+            {
+                return;
+            }
+        }
+
+        if (cursor.Current == '/' && cursor.Peek() == '*')
+        {
+            StateMachine.PushState<CommentState>();
+            return;
+        }
+
+        if (cursor.Current is ';')
+        {
+            _hasSemicolonInBuffer = true;
+            return;
+        }
+
+        if (cursor.Current is '}')
+        {
+            _hasSemicolonInBuffer = false;
+            StateMachine.PopState();
+        }
+
+        if (_hasSemicolonInBuffer)
+        {
+            _hasSemicolonInBuffer = false;
+            output.Append(';');
+        }
+
+        output.Append(cursor.Current);
+    }
+}

--- a/Kaskada.Minify/States/SelectorState.cs
+++ b/Kaskada.Minify/States/SelectorState.cs
@@ -1,0 +1,54 @@
+﻿namespace Kaskada.Minify.States;
+
+internal class SelectorState : State
+{
+    private static readonly HashSet<char> PreDelimiters = new()
+    {
+        '[', '{', ':', ';', '=', '!', '&', '|', '?', '+', '-', '~', '*', '/', '\n', '\r', '>', ',', '@'
+    };
+
+    private static readonly HashSet<char> PostDelimiters = new()
+    {
+        '(', '[', '{', ':', ';', '=', '!', '&', '|', '?', '+', '-', '~', '*', '/', '\n', '\r', '>', ',', '@', ')', '}'
+    };
+
+    public SelectorState(StateMachine stateMachine)
+        : base(stateMachine)
+    {
+    }
+
+    public override void Process(ICursor cursor, IOutput output)
+    {
+        if (char.IsWhiteSpace(cursor.Current))
+        {
+            if (char.IsWhiteSpace(cursor.Previous) || PreDelimiters.Contains(cursor.Previous))
+            {
+                return;
+            }
+
+            char? next = cursor.Peek();
+            if (next is null)
+            {
+                return;
+            }
+
+            if (char.IsWhiteSpace(next.Value) || PostDelimiters.Contains(next.Value))
+            {
+                return;
+            }
+        }
+
+        if (cursor.Current is ';')
+        {
+            return;
+        }
+
+        if (cursor.Current is '{')
+        {
+            StateMachine.PopState();
+            StateMachine.PushState<DeclarationState>();
+        }
+
+        output.Append(cursor.Current);
+    }
+}

--- a/Kaskada.Minify/States/State.cs
+++ b/Kaskada.Minify/States/State.cs
@@ -1,0 +1,11 @@
+﻿namespace Kaskada.Minify.States;
+
+internal abstract class State
+{
+    protected readonly StateMachine StateMachine;
+
+    protected State(StateMachine stateMachine)
+        => StateMachine = stateMachine;
+
+    public abstract void Process(ICursor cursor, IOutput output);
+}

--- a/Kaskada.Minify/States/StateMachine.cs
+++ b/Kaskada.Minify/States/StateMachine.cs
@@ -1,0 +1,46 @@
+﻿namespace Kaskada.Minify.States;
+
+internal class StateMachine
+{
+    private readonly Stack<State> _states;
+    private readonly IDictionary<Type, State> _stateTable;
+
+    public StateMachine()
+    {
+        _states = new();
+        _stateTable = new Dictionary<Type, State>
+        {
+            {typeof(WhitespaceState), new WhitespaceState(this)},
+            {typeof(SelectorState), new SelectorState(this)},
+            {typeof(CommentState), new CommentState(this)},
+            {typeof(AtRuleState), new AtRuleState(this)},
+            {typeof(DeclarationState), new DeclarationState(this)},
+        };
+    }
+
+    public void PushState<TState>() where TState : State
+    {
+        Type key = typeof(TState);
+        if (!_stateTable.TryGetValue(
+                key,
+                out State? state))
+        {
+            throw new KaskadaException($"Unknown state type requested: {key.Name}");
+        }
+
+        _states.Push(state);
+    }
+
+    public void PushStateAndProcess<TState>(ICursor cursor,
+        IOutput output) where TState : State
+    {
+        PushState<TState>();
+        Process(cursor, output);
+    }
+
+    public void PopState()
+        => _states.Pop();
+
+    public void Process(ICursor cursor, IOutput output)
+        => _states.Peek().Process(cursor, output);
+}

--- a/Kaskada.Minify/States/WhitespaceState.cs
+++ b/Kaskada.Minify/States/WhitespaceState.cs
@@ -1,0 +1,29 @@
+﻿namespace Kaskada.Minify.States;
+
+internal class WhitespaceState : State
+{
+    public WhitespaceState(StateMachine stateMachine)
+        : base(stateMachine)
+    {
+    }
+
+    public override void Process(ICursor cursor, IOutput output)
+    {
+        if (cursor.Current is '.' or '#' || char.IsLetter(cursor.Current))
+        {
+            StateMachine.PushStateAndProcess<SelectorState>(cursor, output);
+            return;
+        }
+
+        if (cursor.Current == '/' && cursor.Peek() == '*')
+        {
+            StateMachine.PushState<CommentState>();
+            return;
+        }
+
+        if (cursor.Current == '@')
+        {
+            StateMachine.PushStateAndProcess<AtRuleState>(cursor, output);
+        }
+    }
+}


### PR DESCRIPTION
Previous implementation was too naive and didn't allow for much room to expand. Rewrote to stack based state machine. Currently the states represent selectors, declarations, comments and at-rules. 

#1 

